### PR TITLE
Simplifying code and creating skip operation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,5 +3,7 @@ module.exports = {
   rules: {
     'default-case': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    'no-magic-numbers': 'off'
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -139,6 +139,25 @@ export declare function mapAsyncIterable<T, R>(
   mapper: AsyncMapper<T, R>,
 ): AsyncIterable<T>;
 /**
+ * Skips the first offset elements and then yields the next ones
+ * @param it the original iterable
+ * @param offset the number of offset elements
+ */
+ export declare function skipIterable<T>(
+  it: Iterable<T>,
+  offset: number,
+): Iterable<T>;
+
+/**
+ * Skips the first offset elements and then yields the next ones
+ * @param it the original async iterable
+ * @param offset the number of offset elements
+ */
+export declare function skipAsyncIterable<T>(
+  it: AnyIterable<T>,
+  offset: number,
+): AsyncIterable<T>;
+/**
  * Returns an iterable that stop to iterate over the values of the original iterable when the informed condition resolves to true.
  * @param it the original iterable
  * @param predicate the stop condition

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,16 @@ export declare function mapIterable<T, R>(
 ): Iterable<T>;
 
 /**
+ * Returns an async iterable that maps each value of the async iterable using the function provided
+ * @param it the original async iterable or iterable
+ * @param mapper the mapping function
+ */
+export declare function mapAsyncIterable<T, R>(
+  it: AnyIterable<T>,
+  mapper: AsyncMapper<T, R>,
+): AsyncIterable<T>;
+
+/**
  * Add a flatMap augment for the iterable. It will returns a new iterable with tne new mapped item type.
  * @param it the original iterable
  * @param mapper the mapping function
@@ -130,14 +140,13 @@ export declare function flatMapIterable<T>(
 ): Iterable<T extends Iterable<infer R> ? R : never>;
 
 /**
- * Returns an async iterable that maps each value of the async iterable using the function provided
- * @param it the original async iterable or iterable
+ * Add a flatMap augment for the iterable. It will returns a new iterable with tne new mapped item type.
+ * @param it the original iterable
  * @param mapper the mapping function
  */
-export declare function mapAsyncIterable<T, R>(
+export declare function flatMapAsyncIterable<T>(
   it: AnyIterable<T>,
-  mapper: AsyncMapper<T, R>,
-): AsyncIterable<T>;
+): AsyncIterable<T extends AsyncIterable<infer R> ? R : never>;
 /**
  * Skips the first offset elements and then yields the next ones
  * @param it the original iterable

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const {
   addFilterAsync,
   addMapAsync,
   addTakeWhileAsync,
+  skipAsyncIterable,
 } = require('./lib/augmentative-async-iterable');
 const {
   augmentativeToArray,
@@ -22,6 +23,7 @@ const {
   addFilter,
   addMap,
   addTakeWhile,
+  skipIterable,
 } = require('./lib/augmentative-iterable');
 const {
   itClone,
@@ -53,4 +55,6 @@ module.exports = {
   takeWhileIterable,
   resolver,
   resolverAsync,
+  skipIterable,
+  skipAsyncIterable,
 };

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const {
   addFilterAsync,
   addMapAsync,
   addTakeWhileAsync,
+  flatMapAsyncIterable,
   skipAsyncIterable,
 } = require('./lib/augmentative-async-iterable');
 const {
@@ -47,6 +48,7 @@ module.exports = {
   immutableAsync,
   itClone,
   mapAsyncIterable,
+  flatMapAsyncIterable,
   takeWhileAsyncIterable,
   filterIterable,
   mapIterable,

--- a/lib/augmentative-async-iterable.js
+++ b/lib/augmentative-async-iterable.js
@@ -19,6 +19,7 @@ const {
 const {
   getLinkedList,
 } = require('./liked-list');
+const { augmentativeIterate } = require('./augmentative-iterable');
 
 function stepResolveState(
   context,
@@ -34,7 +35,7 @@ function stepResolveState(
   if (context.state === YIELD && context.next) {
     const item = context.next;
     context.type = item.type;
-    chain = item.action(context.result);
+    chain = item.action ? item.action(context.result) : context.result;
   }
   return chain;
 }
@@ -44,6 +45,7 @@ function resolveState(augmentList, wrapper) {
   wrapper.state = YIELD;
   function recursive(chain) {
     while (wrapper.next) {
+      wrapper.currentAi = wrapper.next;
       wrapper.next = wrapper.next.next;
       chain = stepResolveState(wrapper, chain, augmentList);
       if (isPromiseLike(chain)) {
@@ -54,6 +56,14 @@ function resolveState(augmentList, wrapper) {
     return wrapper;
   };
   return recursive();
+}
+
+function flat(sub, wrapper) {
+  if (wrapper.result[Symbol.asyncIterator]) {
+    sub.push(augmentativeIterateAsync.call(wrapper.result, wrapper.currentAi.next));
+  } else {
+    sub.push(augmentativeIterate.call(wrapper.result, wrapper.currentAi.next));
+  }
 }
 
 function augmentativeIterateArrayAsync(augmentList, base, offset) {
@@ -67,7 +77,7 @@ function augmentativeIterateArrayAsync(augmentList, base, offset) {
       do {
         keepGoing = false;
         while (sub.hasSomething()) {
-          const result = (await sub.last().value).next();
+          const result = await sub.last().value.next();
           if (result.done) {
             sub.pop();
           } else {
@@ -82,7 +92,7 @@ function augmentativeIterateArrayAsync(augmentList, base, offset) {
             case STOP:
               return end;
             case FLAT:
-              sub.push(augmentativeIterate.call(wrapper.result, wrapper.currentAi.next));
+              flat(sub, wrapper);
               keepGoing = true;
               break iterator;
             case YIELD:
@@ -113,7 +123,7 @@ function augmentativeIterateAsyncIterable(augmentList, base, offset) {
           keepGoing = !(await it.next()).done;
         } else {
           while (sub.hasSomething()) {
-            const result = (await sub.last()).value.next();
+            const result = await sub.last().value.next();
             if (result.done) {
               sub.pop();
             } else {
@@ -129,7 +139,7 @@ function augmentativeIterateAsyncIterable(augmentList, base, offset) {
               case STOP:
                 return end;
               case FLAT:
-                sub.push(augmentativeIterate.call(wrapper.result, wrapper.currentAi.next));
+                flat(sub, wrapper);
                 keepGoing = true;
                 break iterator;
               case YIELD:
@@ -206,6 +216,12 @@ const takeWhileAsyncIterable = getAugmentIterable(
   STOP,
 );
 
+const flatMapAsyncIterable = getAugmentIterable(
+  Symbol.asyncIterator,
+  augmentativeIterateAsync,
+  FLAT,
+);
+
 const skipAsyncIterable = getSkippedAugmentIterable(
   Symbol.asyncIterator,
   augmentativeIterateAsync,
@@ -225,5 +241,6 @@ module.exports = {
   filterAsyncIterable,
   mapAsyncIterable,
   takeWhileAsyncIterable,
+  flatMapAsyncIterable,
   skipAsyncIterable,
 };

--- a/lib/augmentative-async-iterable.js
+++ b/lib/augmentative-async-iterable.js
@@ -2,14 +2,11 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable no-magic-numbers */
 const {
-  getArrayOperator,
-  getItOperator,
-  getStateProcessorAsync,
   processActionResult,
   getAugmentIterable,
   resolverAsync,
-  resolver,
   isPromiseLike,
+  end,
 } = require('./augments-utils');
 const {
   augments,
@@ -17,7 +14,11 @@ const {
   YIELD,
   IGNORE,
   STOP,
+  FLAT,
 } = require('./augments-types');
+const {
+  getLinkedList,
+} = require('./liked-list');
 
 function stepResolveState(
   context,
@@ -39,6 +40,8 @@ function stepResolveState(
 }
 
 function resolveState(augmentList, wrapper) {
+  wrapper.next = augmentList;
+  wrapper.state = YIELD;
   function recursive(chain) {
     while (wrapper.next) {
       wrapper.next = wrapper.next.next;
@@ -53,28 +56,123 @@ function resolveState(augmentList, wrapper) {
   return recursive();
 }
 
-function augmentativeIterateAsync() {
-  const augmentList = this[augments] || {};
-  const base = this[baseIterable] || this;
-  let itResolver;
-  let it;
-  if (base[Symbol.asyncIterator]) {
-    itResolver = resolverAsync;
-    it = base[Symbol.asyncIterator]();
-  } else {
-    itResolver = resolver;
-    it = base[Symbol.iterator]();
-  }
-
-  const operator = Array.isArray(base) ?
-    getArrayOperator(base) :
-    getItOperator(it, itResolver);
+function augmentativeIterateArrayAsync(augmentList, base, offset) {
+  const length = base.length;
+  const sub = getLinkedList();
+  let i = -1 + offset;
 
   return {
-    next: getStateProcessorAsync(operator, itResolver, resolveState, augmentList),
-    return: it.return ? it.return.bind(it) : undefined,
-    throw: it.throw ? it.throw.bind(it) : undefined,
+    next: async () => {
+      let keepGoing;
+      do {
+        keepGoing = false;
+        while (sub.hasSomething()) {
+          const result = (await sub.last().value).next();
+          if (result.done) {
+            sub.pop();
+          } else {
+            return result;
+          }
+        }
+        iterator:
+        while (++i < length) {
+          const wrapper = { result: base[i] };
+          await resolveState(augmentList, wrapper);
+          switch (wrapper.state) {
+            case STOP:
+              return end;
+            case FLAT:
+              sub.push(augmentativeIterate.call(wrapper.result, wrapper.currentAi.next));
+              keepGoing = true;
+              break iterator;
+            case YIELD:
+              return {
+                done: false,
+                value: wrapper.result,
+              };
+          };
+        }
+      } while (keepGoing);
+
+      return end;
+    },
   };
+}
+
+function augmentativeIterateAsyncIterable(augmentList, base, offset) {
+  const sub = getLinkedList();
+  const it = base[Symbol.asyncIterator] ? base[Symbol.asyncIterator]() : base[Symbol.iterator]();
+
+  return {
+    next: async () => {
+      let keepGoing;
+      do {
+        keepGoing = false;
+        if (offset > 0) {
+          keepGoing = !(await it.next()).done;
+        } else {
+          while (sub.hasSomething()) {
+            const result = (await sub.last()).value.next();
+            if (result.done) {
+              sub.pop();
+            } else {
+              return result;
+            }
+          }
+          let next = await it.next();
+          iterator:
+          while (!next.done) {
+            const wrapper = { result: next.value };
+            await resolveState(augmentList, wrapper);
+            switch (wrapper.state) {
+              case STOP:
+                return end;
+              case FLAT:
+                sub.push(augmentativeIterate.call(wrapper.result, wrapper.currentAi.next));
+                keepGoing = true;
+                break iterator;
+              case YIELD:
+                return {
+                  done: false,
+                  value: wrapper.result,
+                };
+            };
+            next = await it.next();
+          }
+        }
+      } while (keepGoing);
+
+      return end;
+    },
+    error: it.error?.bind(it),
+    return: it.return?.bind(it),
+  };
+}
+
+function getIterableParameters(self, next) {
+  let augmentList;
+  let base;
+  if (!next) {
+    augmentList = self[augments] || {};
+    base = self[baseIterable] || self;
+  } else {
+    base = {
+      [Symbol.asyncIterator]: augmentativeIterateAsync.bind(self),
+    };
+    augmentList = { next, last: next };
+  }
+
+  return { augmentList, base };
+}
+
+function augmentativeIterateAsync(next, offset = 0) {
+  const { augmentList, base } = getIterableParameters(this, next);
+
+  if (Array.isArray(base)) {
+    return augmentativeIterateArrayAsync(augmentList, base, offset);
+  }
+
+  return augmentativeIterateAsyncIterable(augmentList, base, offset);
 }
 
 async function augmentativeForEachAsync(

--- a/lib/augmentative-async-iterable.js
+++ b/lib/augmentative-async-iterable.js
@@ -4,13 +4,13 @@
 const {
   processActionResult,
   getAugmentIterable,
+  getSkippedAugmentIterable,
   resolverAsync,
   isPromiseLike,
   end,
+  getIterableParameters,
 } = require('./augments-utils');
 const {
-  augments,
-  baseIterable,
   YIELD,
   IGNORE,
   STOP,
@@ -109,6 +109,7 @@ function augmentativeIterateAsyncIterable(augmentList, base, offset) {
       do {
         keepGoing = false;
         if (offset > 0) {
+          offset--;
           keepGoing = !(await it.next()).done;
         } else {
           while (sub.hasSomething()) {
@@ -149,24 +150,8 @@ function augmentativeIterateAsyncIterable(augmentList, base, offset) {
   };
 }
 
-function getIterableParameters(self, next) {
-  let augmentList;
-  let base;
-  if (!next) {
-    augmentList = self[augments] || {};
-    base = self[baseIterable] || self;
-  } else {
-    base = {
-      [Symbol.asyncIterator]: augmentativeIterateAsync.bind(self),
-    };
-    augmentList = { next, last: next };
-  }
-
-  return { augmentList, base };
-}
-
-function augmentativeIterateAsync(next, offset = 0) {
-  const { augmentList, base } = getIterableParameters(this, next);
+function augmentativeIterateAsync(next) {
+  const { augmentList, base, offset } = getIterableParameters(this, next, Symbol.asyncIterator, augmentativeIterateAsync);
 
   if (Array.isArray(base)) {
     return augmentativeIterateArrayAsync(augmentList, base, offset);
@@ -221,6 +206,11 @@ const takeWhileAsyncIterable = getAugmentIterable(
   STOP,
 );
 
+const skipAsyncIterable = getSkippedAugmentIterable(
+  Symbol.asyncIterator,
+  augmentativeIterateAsync,
+);
+
 const addFilterAsync = getAugmentIterable(Symbol.asyncIterator, augmentativeIterateAsync, IGNORE);
 const addMapAsync = getAugmentIterable(Symbol.asyncIterator, augmentativeIterateAsync, YIELD);
 const addTakeWhileAsync = getAugmentIterable(Symbol.asyncIterator, augmentativeIterateAsync, STOP);
@@ -235,4 +225,5 @@ module.exports = {
   filterAsyncIterable,
   mapAsyncIterable,
   takeWhileAsyncIterable,
+  skipAsyncIterable,
 };

--- a/lib/augmentative-async-iterable.js
+++ b/lib/augmentative-async-iterable.js
@@ -1,6 +1,5 @@
 'use strict';
-/* eslint-disable @typescript-eslint/no-use-before-define */
-/* eslint-disable no-magic-numbers */
+
 const {
   processActionResult,
   getAugmentIterable,

--- a/lib/augmentative-iterable.js
+++ b/lib/augmentative-iterable.js
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 'use strict';
+
 const {
   processActionResult,
   getAugmentIterable,

--- a/lib/augmentative-iterable.js
+++ b/lib/augmentative-iterable.js
@@ -1,11 +1,9 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 'use strict';
 const {
-  getArrayOperator,
-  getItOperator,
-  getStateProcessor,
   processActionResult,
   getAugmentIterable,
-  resolver,
+  end,
 } = require('./augments-utils');
 const {
   baseIterable,
@@ -15,6 +13,9 @@ const {
   STOP,
   FLAT,
 } = require('./augments-types');
+const {
+  getLinkedList,
+} = require('./liked-list');
 
 function resolveState(augmentList, wrapper) {
   wrapper.state = YIELD;
@@ -29,27 +30,125 @@ function resolveState(augmentList, wrapper) {
     }
     ai = ai.next;
   }
-};
-
-function getIterableParameters(self) {
-  const augmentList = self[augments] || {};
-  const base = self[baseIterable] || self;
-
-  const operator = Array.isArray(base) ?
-    getArrayOperator(base) :
-    getItOperator(base[Symbol.iterator](), resolver);
-
-  return { operator, augmentList, base };
 }
 
-function augmentativeIterate() {
-  const { operator, augmentList, base } = getIterableParameters(this);
+function getIterableParameters(self, next) {
+  let augmentList;
+  let base;
+  if (!next) {
+    augmentList = self[augments] || {};
+    base = self[baseIterable] || self;
+  } else {
+    base = {
+      [Symbol.iterator]: augmentativeIterate.bind(self),
+    };
+    augmentList = { next, last: next };
+  }
+
+  return { augmentList, base };
+}
+
+function augmentativeIterateArray(augmentList, base, offset) {
+  const length = base.length;
+  const sub = getLinkedList();
+  let i = -1 + offset;
 
   return {
-    next: getStateProcessor(operator, resolveState, augmentList, getIterableParameters),
-    return: base.return ? base.return.bind(base) : undefined,
-    throw: base.throw ? base.throw.bind(base) : undefined,
+    next: () => {
+      let keepGoing;
+      do {
+        keepGoing = false;
+        while (sub.hasSomething()) {
+          const result = sub.last().value.next();
+          if (result.done) {
+            sub.pop();
+          } else {
+            return result;
+          }
+        }
+        iterator:
+        while (++i < length) {
+          const wrapper = { result: base[i] };
+          resolveState(augmentList, wrapper);
+          switch (wrapper.state) {
+            case STOP:
+              return end;
+            case FLAT:
+              sub.push(augmentativeIterate.call(wrapper.result, wrapper.currentAi.next));
+              keepGoing = true;
+              break iterator;
+            case YIELD:
+              return {
+                done: false,
+                value: wrapper.result,
+              };
+          };
+        }
+      } while (keepGoing);
+
+      return end;
+    },
   };
+}
+
+function augmentativeIterateIterable(augmentList, base, offset) {
+  const sub = getLinkedList();
+  const it = base[Symbol.iterator]();
+
+  return {
+    next: () => {
+      let keepGoing;
+      do {
+        keepGoing = false;
+        if (offset > 0) {
+          keepGoing = !it.next().done;
+        } else {
+          while (sub.hasSomething()) {
+            const result = sub.last().value.next();
+            if (result.done) {
+              sub.pop();
+            } else {
+              return result;
+            }
+          }
+          let next = it.next();
+          iterator:
+          while (!next.done) {
+            const wrapper = { result: next.value };
+            resolveState(augmentList, wrapper);
+            switch (wrapper.state) {
+              case STOP:
+                return end;
+              case FLAT:
+                sub.push(augmentativeIterate.call(wrapper.result, wrapper.currentAi.next));
+                keepGoing = true;
+                break iterator;
+              case YIELD:
+                return {
+                  done: false,
+                  value: wrapper.result,
+                };
+            };
+            next = it.next();
+          }
+        }
+      } while (keepGoing);
+
+      return end;
+    },
+    error: it.error?.bind(it),
+    return: it.return?.bind(it),
+  };
+}
+
+function augmentativeIterate(next, offset = 0) {
+  const { augmentList, base } = getIterableParameters(this, next);
+
+  if (Array.isArray(base)) {
+    return augmentativeIterateArray(augmentList, base, offset);
+  }
+
+  return augmentativeIterateIterable(augmentList, base, offset);
 }
 
 function augmentativeForEach(

--- a/lib/augmentative-iterable.js
+++ b/lib/augmentative-iterable.js
@@ -4,10 +4,10 @@ const {
   processActionResult,
   getAugmentIterable,
   end,
+  getSkippedAugmentIterable,
+  getIterableParameters,
 } = require('./augments-utils');
 const {
-  baseIterable,
-  augments,
   YIELD,
   IGNORE,
   STOP,
@@ -30,22 +30,6 @@ function resolveState(augmentList, wrapper) {
     }
     ai = ai.next;
   }
-}
-
-function getIterableParameters(self, next) {
-  let augmentList;
-  let base;
-  if (!next) {
-    augmentList = self[augments] || {};
-    base = self[baseIterable] || self;
-  } else {
-    base = {
-      [Symbol.iterator]: augmentativeIterate.bind(self),
-    };
-    augmentList = { next, last: next };
-  }
-
-  return { augmentList, base };
 }
 
 function augmentativeIterateArray(augmentList, base, offset) {
@@ -101,6 +85,7 @@ function augmentativeIterateIterable(augmentList, base, offset) {
       do {
         keepGoing = false;
         if (offset > 0) {
+          offset--;
           keepGoing = !it.next().done;
         } else {
           while (sub.hasSomething()) {
@@ -141,8 +126,8 @@ function augmentativeIterateIterable(augmentList, base, offset) {
   };
 }
 
-function augmentativeIterate(next, offset = 0) {
-  const { augmentList, base } = getIterableParameters(this, next);
+function augmentativeIterate(next) {
+  const { augmentList, base, offset } = getIterableParameters(this, next, Symbol.iterator, augmentativeIterate);
 
   if (Array.isArray(base)) {
     return augmentativeIterateArray(augmentList, base, offset);
@@ -196,6 +181,11 @@ const flatMapIterable = getAugmentIterable(
   FLAT,
 );
 
+const skipIterable = getSkippedAugmentIterable(
+  Symbol.iterator,
+  augmentativeIterate,
+);
+
 const addFilter = getAugmentIterable(Symbol.iterator, augmentativeIterate, IGNORE);
 const addMap = getAugmentIterable(Symbol.iterator, augmentativeIterate, YIELD);
 const addTakeWhile = getAugmentIterable(Symbol.iterator, augmentativeIterate, STOP);
@@ -211,4 +201,5 @@ module.exports = {
   mapIterable,
   takeWhileIterable,
   flatMapIterable,
+  skipIterable,
 };

--- a/lib/augments-types.js
+++ b/lib/augments-types.js
@@ -2,9 +2,6 @@
 /* eslint-disable no-magic-numbers */
 
 module.exports = {
-  augments: Symbol('AugmentSymbol'),
-  baseIterable: Symbol('BaseIterableSymbol'),
-  offsetSymbol: Symbol('offset'),
   YIELD: 0,
   IGNORE: 1,
   STOP: 2,

--- a/lib/augments-types.js
+++ b/lib/augments-types.js
@@ -4,6 +4,7 @@
 module.exports = {
   augments: Symbol('AugmentSymbol'),
   baseIterable: Symbol('BaseIterableSymbol'),
+  offsetSymbol: Symbol('offset'),
   YIELD: 0,
   IGNORE: 1,
   STOP: 2,

--- a/lib/augments-utils.js
+++ b/lib/augments-utils.js
@@ -1,18 +1,15 @@
 'use strict';
 const {
-  YIELD,
   STOP,
   IGNORE,
   augments,
   baseIterable,
   FLAT,
 } = require('./augments-types');
-const { getLinkedList } = require('./liked-list');
 
 const end = {
   done: true,
 };
-const promiseEnd = Promise.resolve(end);
 function isPromiseLike(p) {
   return p && typeof p.then === 'function';
 }
@@ -22,156 +19,6 @@ function resolverAsync(
   callback,
 ) {
   return isPromiseLike(promise) ? promise.then(callback) : callback(promise);
-}
-
-function getKeepGoing(
-  it,
-  wrapper,
-  keepGoingResolver,
-) {
-  return () => keepGoingResolver(it.next(), (x) => !(wrapper.next = x).done);
-}
-
-function getValue(wrapper) {
-  return () => wrapper.next.value;
-}
-
-function stateResultResolver(
-  recursive,
-) {
-  return (wrapper) => () => {
-    const { state, result } = wrapper;
-    switch (state) {
-      case YIELD:
-        return {
-          done: false, value: result,
-        };
-      case STOP:
-        return end;
-      default:
-        return recursive();
-    }
-  };
-}
-
-function stepProcessor(
-  resolveState,
-  augmentList,
-  value,
-  resultResolver,
-) {
-  return (x) => {
-    if (x) {
-      const wrapper = { result: value(), next: augmentList, state: YIELD };
-      const result = resolveState(augmentList, wrapper);
-      return resolverAsync(result, resultResolver(wrapper));
-    }
-    return promiseEnd;
-  };
-}
-
-function getArrayOperator(base) {
-  const length = base.length;
-  let i = -1;
-  return [() => ++i < length, () => base[i]];
-}
-
-function getItOperator(
-  it,
-  keepGoingResolver,
-) {
-  const wrapper = {};
-  return [getKeepGoing(it, wrapper, keepGoingResolver), getValue(wrapper)];
-}
-
-function areThereAnyFlat(augmentList) {
-  let { next } = augmentList;
-  while (next) {
-    if (next.type === FLAT) {
-      return true;
-    }
-    next = next.next;
-  }
-  return false;
-}
-
-function getStateProcessor(
-  operator,
-  resolveState,
-  rootAugmentList,
-  getIterableParameters,
-) {
-  let [keepGoing, value] = operator;
-  let wrapper = {};
-  let augmentList = rootAugmentList;
-  let stack;
-  if (areThereAnyFlat(augmentList)) {
-    stack = getLinkedList();
-    stack.push({ operator, wrapper, augmentList });
-  }
-  return () => {
-    while (keepGoing) {
-      let mustKeepGoing;
-      // eslint-disable-next-line no-cond-assign
-      while (mustKeepGoing = keepGoing()) {
-        wrapper.result = value();
-        resolveState(augmentList, wrapper);
-        if (wrapper.state === STOP) {
-          mustKeepGoing = false;
-          break;
-        } else if (wrapper.state === FLAT) {
-          const subIterable = getIterableParameters(wrapper.result);
-          subIterable.wrapper = {};
-          if (subIterable.augmentList.last) {
-            subIterable.augmentList.last.next = wrapper.currentAi.next;
-          } else {
-            subIterable.augmentList.last = subIterable.augmentList.next = wrapper.currentAi.next;
-          }
-          stack.push(subIterable);
-          break;
-        }
-        if (wrapper.state === YIELD) {
-          return {
-            done: false,
-            value: wrapper.result,
-          };
-        }
-      }
-      keepGoing = undefined;
-      if (stack) {
-        if (!mustKeepGoing) {
-          stack.pop();
-        }
-        const node = stack.peek(stack);
-        if (node) {
-          [keepGoing, value] = node.operator;
-          wrapper = node.wrapper;
-          augmentList = node.augmentList;
-        }
-      }
-    }
-
-    return end;
-  };
-}
-
-function getStateProcessorAsync(
-  operator,
-  keepGoingResolver,
-  resolveState,
-  augmentList,
-) {
-  const [keepGoing, value] = operator;
-  return () => {
-    function recursive() {
-      return keepGoingResolver(
-        keepGoing(),
-        stepProcessor(resolveState, augmentList, value, stateResultResolver(recursive)),
-      );
-    }
-
-    return recursive();
-  };
 }
 
 function processActionResult(
@@ -242,14 +89,11 @@ function resolver(value, callback) {
 }
 
 module.exports = {
-  getArrayOperator,
-  getItOperator,
-  getStateProcessor,
-  getStateProcessorAsync,
   processActionResult,
   getAugmentIterable,
   isPromiseLike,
   itClone,
   resolver,
   resolverAsync,
+  end,
 };

--- a/lib/augments-utils.js
+++ b/lib/augments-utils.js
@@ -2,12 +2,12 @@
 const {
   STOP,
   IGNORE,
-  augments,
-  baseIterable,
   FLAT,
-  offsetSymbol,
 } = require('./augments-types');
 
+const offsetSymbol = Symbol('offset');
+const baseIterable = Symbol('BaseIterableSymbol');
+const augments = Symbol('AugmentSymbol');
 const end = {
   done: true,
 };

--- a/lib/augments-utils.js
+++ b/lib/augments-utils.js
@@ -5,6 +5,7 @@ const {
   augments,
   baseIterable,
   FLAT,
+  offsetSymbol,
 } = require('./augments-types');
 
 const end = {
@@ -60,12 +61,32 @@ function itClone(it) {
   };
 }
 
+function getSkippedAugmentIterable(
+  iteratorType,
+  augmentativeIterate,
+) {
+  return function (it, offset = 0) {
+    const augmentList = it[augments];
+    let baseOffset;
+
+    if (!augmentList?.last) {
+      baseOffset = it[offsetSymbol];
+    }
+
+    return {
+      [iteratorType]: augmentativeIterate,
+      [baseIterable]: it,
+      [offsetSymbol]: (baseOffset || 0) + Math.max(offset, 0),
+    };
+  };
+}
+
 function getAugmentIterable(
   iteratorType,
   augmentativeIterate,
   type,
 ) {
-  return function (it, action) {
+  return function (it, action,) {
     const augmentList = it[augments];
     const augment = {
       type,
@@ -88,12 +109,31 @@ function resolver(value, callback) {
   return callback(value);
 }
 
+function getIterableParameters(self, next, iteratorSymbol, augmentativeIterate) {
+  let augmentList;
+  let base;
+  const offset = self[offsetSymbol] || 0;
+  if (!next) {
+    augmentList = self[augments] || {};
+    base = self[baseIterable] || self;
+  } else {
+    base = {
+      [iteratorSymbol]: augmentativeIterate.bind(self),
+    };
+    augmentList = { next, last: next };
+  }
+
+  return { augmentList, base, offset };
+}
+
 module.exports = {
   processActionResult,
   getAugmentIterable,
+  getSkippedAugmentIterable,
   isPromiseLike,
   itClone,
   resolver,
   resolverAsync,
   end,
+  getIterableParameters,
 };

--- a/lib/liked-list.js
+++ b/lib/liked-list.js
@@ -1,6 +1,6 @@
-function getLinkedList() {
-  let first;
-  let last;
+function getLinkedList(bootNode) {
+  let first = bootNode;
+  let last = bootNode;
   return {
     hasSomething() {
       return !!first;
@@ -26,28 +26,28 @@ function getLinkedList() {
     },
     next() {
       if (first) {
-        const { value } = first;
+        const result = first;
         first = first.next;
         if (!first) {
           last = first;
         }
-        return value;
+        return result;
       }
     },
-    peek() {
-      if (last) {
-        const { value } = last;
-        return value;
-      }
+    first() {
+      return first;
+    },
+    last() {
+      return last;
     },
     pop() {
       if (last) {
-        const { value } = last;
+        const result = last;
         last = last.previous;
         if (!last) {
           first = last;
         }
-        return value;
+        return result;
       }
     },
   };

--- a/test/async-iterable.spec.ts
+++ b/test/async-iterable.spec.ts
@@ -8,6 +8,7 @@ import {
   addTakeWhileAsync,
   addFilterAsync,
   skipAsyncIterable,
+  flatMapAsyncIterable,
 } from '../index';
 import { expect } from 'chai';
 import { stub } from 'sinon';
@@ -229,5 +230,44 @@ describe('AsyncIterable', () => {
     const result = await augmentativeToArrayAsync.call(skipped);
 
     expect(result).to.be.eql([6]);
+  });
+
+  it('should apply flatMap over array', async () => {
+    const original = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+
+    const transformed = flatMapAsyncIterable(original);
+    const result = await augmentativeToArrayAsync.call(transformed);
+
+    expect(result).to.be.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('should apply flatMap over array of async iterable', async () => {
+    const original = [
+      toAsync([1, 2, 3]),
+      toAsync([4, 5, 6]),
+      toAsync([7, 8, 9]),
+    ];
+
+    const transformed = flatMapAsyncIterable(original);
+    const result = await augmentativeToArrayAsync.call(transformed);
+
+    expect(result).to.be.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('should apply flatMap over an async iterable of async iterables', async () => {
+    const original = toAsync([
+      toAsync([1, 2, 3]),
+      toAsync([4, 5, 6]),
+      toAsync([7, 8, 9]),
+    ]);
+
+    const transformed = flatMapAsyncIterable(original);
+    const result = await augmentativeToArrayAsync.call(transformed);
+
+    expect(result).to.be.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 });

--- a/test/async-iterable.spec.ts
+++ b/test/async-iterable.spec.ts
@@ -7,11 +7,16 @@ import {
   addMapAsync,
   addTakeWhileAsync,
   addFilterAsync,
+  skipAsyncIterable,
 } from '../index';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import 'chai-callslike';
 import { getAsync } from './get-async';
+
+async function* toAsync(items) {
+  yield* items;
+}
 
 describe('AsyncIterable', () => {
   it('should apply map', async () => {
@@ -180,5 +185,49 @@ describe('AsyncIterable', () => {
     expect(callFilter).to.have.callsLike([1], [2], [3], [4]);
     expect(callTakeWhile).to.have.callsLike([1], [3], [4]);
     expect(callMap).to.have.callsLike([1], [3]);
+  });
+
+  it('should work with skip operation over an array', async () => {
+    const original = [1, 2, 3, 4, 5, 6];
+
+    const skipped = skipAsyncIterable(original, 2);
+    const filtered = filterAsyncIterable(skipped, (x) => x % 2 === 0);
+
+    const result = await augmentativeToArrayAsync.call(filtered);
+
+    expect(result).to.be.eql([4, 6]);
+  });
+
+  it('should work with skip operation over an array with negative skip', async () => {
+    const original = [2, 3, 4, 5, 6];
+
+    const skipped = skipAsyncIterable(original, -2);
+    const filtered = filterAsyncIterable(skipped, (x) => x % 2 === 0);
+
+    const result = await augmentativeToArrayAsync.call(filtered);
+
+    expect(result).to.be.eql([2, 4, 6]);
+  });
+
+  it('should work with skip operation over an async iterable', async () => {
+    const original = toAsync([1, 2, 3, 4, 5, 6]);
+
+    const skipped = skipAsyncIterable(original, 2);
+    const filtered = filterAsyncIterable(skipped, (x) => x % 2 === 0);
+
+    const result = await augmentativeToArrayAsync.call(filtered);
+
+    expect(result).to.be.eql([4, 6]);
+  });
+
+  it('should work with skip operation over an augmentative iterable', async () => {
+    const original = [1, 2, 3, 4, 5, 6];
+
+    const filtered = filterAsyncIterable(original, (x) => x % 2 === 0);
+    const skipped = skipAsyncIterable(filtered, 2);
+
+    const result = await augmentativeToArrayAsync.call(skipped);
+
+    expect(result).to.be.eql([6]);
   });
 });

--- a/test/iterable.spec.ts
+++ b/test/iterable.spec.ts
@@ -9,6 +9,7 @@ import {
   addTakeWhile,
   addMapAsync,
   flatMapIterable,
+  skipIterable,
 } from '../index';
 import { expect } from 'chai';
 import { stub } from 'sinon';
@@ -246,5 +247,49 @@ describe('Iterable', () => {
     expect(callFilter).to.have.callsLike([1], [2], [3], [4]);
     expect(callTakeWhile).to.have.callsLike([1], [3], [4]);
     expect(callMap).to.have.callsLike([1], [3]);
+  });
+
+  it('should work with skip operation over an array', () => {
+    const original = [1, 2, 3, 4, 5, 6];
+
+    const skipped = skipIterable(original, 2);
+    const filtered = filterIterable(skipped, (x) => x % 2 === 0);
+
+    const result = augmentativeToArray.call(filtered);
+
+    expect(result).to.be.eql([4, 6]);
+  });
+
+  it('should work with skip operation over an array with negative skip', () => {
+    const original = [2, 3, 4, 5, 6];
+
+    const skipped = skipIterable(original, -2);
+    const filtered = filterIterable(skipped, (x) => x % 2 === 0);
+
+    const result = augmentativeToArray.call(filtered);
+
+    expect(result).to.be.eql([2, 4, 6]);
+  });
+
+  it('should work with skip operation over an iterable', () => {
+    const original = [1, 2, 3, 4, 5, 6][Symbol.iterator]();
+
+    const skipped = skipIterable(original, 2);
+    const filtered = filterIterable(skipped, (x) => x % 2 === 0);
+
+    const result = augmentativeToArray.call(filtered);
+
+    expect(result).to.be.eql([4, 6]);
+  });
+
+  it('should work with skip operation over an augmentative iterable', () => {
+    const original = [1, 2, 3, 4, 5, 6];
+
+    const filtered = filterIterable(original, (x) => x % 2 === 0);
+    const skipped = skipIterable(filtered, 2);
+
+    const result = augmentativeToArray.call(skipped);
+
+    expect(result).to.be.eql([6]);
   });
 });

--- a/test/iterable.spec.ts
+++ b/test/iterable.spec.ts
@@ -43,12 +43,24 @@ describe('Iterable', () => {
     expect(Array.from(transformed)).to.be.eql([1, 2, 3]);
   });
 
-  it('should apply flatMap', () => {
+  it('should apply flatMap over array', () => {
     const original = [
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9],
     ];
+
+    const transformed = flatMapIterable(original);
+
+    expect(Array.from(transformed)).to.be.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('should apply flatMap', () => {
+    const original = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ][Symbol.iterator]();
 
     const transformed = flatMapIterable(original);
 
@@ -85,12 +97,27 @@ describe('Iterable', () => {
     expect(Array.from(map3)).to.be.eql(['5', '8', '11']);
   });
 
+  it('should augment flatMap over an already augmented iterable over array', () => {
+    const original = [0, 1, 2];
+
+    const expanded = mapIterable(original, (x) => [
+      1 + 3 * x,
+      2 + 3 * x,
+      3 + 3 * x,
+    ]);
+    const flattened = flatMapIterable(expanded);
+    const filtered = filterIterable(flattened, (x) => x % 3);
+    const mapped = mapIterable(filtered, (x) => x * 2);
+
+    expect(Array.from(mapped)).to.be.eql([2, 4, 8, 10, 14, 16]);
+  });
+
   it('should accumulate augmentative arguments with flatMap', () => {
     const original = [
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9],
-    ];
+    ][Symbol.iterator]();
 
     const flattened = flatMapIterable(original);
     const filtered = filterIterable(flattened, (x) => x % 3);
@@ -99,8 +126,23 @@ describe('Iterable', () => {
     expect(Array.from(mapped)).to.be.eql([2, 4, 8, 10, 14, 16]);
   });
 
-  it('should augment flatMap over an already augmented iterable', () => {
+  it('should augment flatMap over an already augmented iterable over array', () => {
     const original = [0, 1, 2];
+
+    const expanded = mapIterable(original, (x) => [
+      1 + 3 * x,
+      2 + 3 * x,
+      3 + 3 * x,
+    ]);
+    const flattened = flatMapIterable(expanded);
+    const filtered = filterIterable(flattened, (x) => x % 3);
+    const mapped = mapIterable(filtered, (x) => x * 2);
+
+    expect(Array.from(mapped)).to.be.eql([2, 4, 8, 10, 14, 16]);
+  });
+
+  it('should augment flatMap over an already augmented iterable', () => {
+    const original = [0, 1, 2][Symbol.iterator]();
 
     const expanded = mapIterable(original, (x) => [
       1 + 3 * x,


### PR DESCRIPTION
This is a very hard to maintain package and I understood that, for the sake of maintainability, it would be better if I started to repeat some codes. Also, this will bring some minor performance improvements overall, but nothing too important, accordingly to my tests.

All the previous operations are still working, as the unit tests pointed out, and I also already tested fluent-iterable using this new version of the package.

In this PR, I also implemented the operations skipIterable and skipAsyncIterable, which does what skip and skipAsync does in fluent-iterable, but with some performance improvements when it's the first operation of the chain and the original iterable is an array. In this case, we just start the iteration directly from the desired position

Finally, the operation flatAsync was also implemented. flat already exists for iterables, but its async counterpart hasn't been implement until now.