### PR TITLE
feat: making async iterable to be runned synchronously everytime poss…

### DIFF
--- a/.github/workflows/benchmark-14.yml
+++ b/.github/workflows/benchmark-14.yml
@@ -1,0 +1,23 @@
+# This is a basic workflow to help you get started with Actions
+
+name: benchmark-14
+on:
+  workflow_dispatch:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: install
+        run: npm ci
+      - name: "Benchmark"
+        run: npm run test:benchmark

--- a/.github/workflows/benchmark-14.yml
+++ b/.github/workflows/benchmark-14.yml
@@ -2,6 +2,10 @@
 
 name: benchmark-14
 on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
     branches: [master]
 

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -7,7 +7,8 @@
     "coverage",
     ".eslintrc.js",
     "test",
-    "dist"
+    "dist",
+    "test-benchmark"
   ],
   "reporter": [
     "html",

--- a/index.d.ts
+++ b/index.d.ts
@@ -135,18 +135,20 @@ export declare function mapAsyncIterable<T, R>(
  * @param it the original iterable
  * @param mapper the mapping function
  */
-export declare function flatMapIterable<T>(
+export declare function flatMapIterable<T, R = T extends AnyIterable<infer Sub> ? Sub : never>(
   it: Iterable<T>,
-): Iterable<T extends Iterable<infer R> ? R : never>;
+  mapper?: AsyncMapper<T, AnyIterable<R>>,
+): Iterable<R>;
 
 /**
  * Add a flatMap augment for the iterable. It will returns a new iterable with tne new mapped item type.
  * @param it the original iterable
  * @param mapper the mapping function
  */
-export declare function flatMapAsyncIterable<T>(
+export declare function flatMapAsyncIterable<T, R = T extends AnyIterable<infer Sub> ? Sub : never>(
   it: AnyIterable<T>,
-): AsyncIterable<T extends AsyncIterable<infer R> ? R : never>;
+  mapper?: AsyncMapper<T, AnyIterable<R>>,
+): AsyncIterable<R>;
 /**
  * Skips the first offset elements and then yields the next ones
  * @param it the original iterable

--- a/lib/augmentative-async-iterable.js
+++ b/lib/augmentative-async-iterable.js
@@ -16,7 +16,7 @@ const {
   FLAT,
 } = require('./augments-types');
 const {
-  getLinkedList,
+  getStack,
 } = require('./liked-list');
 const { augmentativeIterate } = require('./augmentative-iterable');
 
@@ -65,35 +65,170 @@ function flat(sub, wrapper) {
   }
 }
 
+function syncToAsyncFactory(sub, asyncNext) {
+  async function asyncSub(result) {
+    result = await result;
+    if (result.done) {
+      sub.pop();
+      return asyncNext();
+    }
+    return result;
+  }
+
+  async function asyncProcResolving(wrapper, resolving) {
+    if (isPromiseLike(resolving)) {
+      await resolving;
+    }
+    switch (wrapper.state) {
+      case STOP:
+        return end;
+      case FLAT:
+        flat(sub, wrapper);
+        return asyncNext();
+      case YIELD:
+        return {
+          done: false,
+          value: wrapper.result,
+        };
+      default:
+        return asyncNext();
+    };
+  }
+
+  return { asyncSub, asyncProcResolving };
+}
+
 function augmentativeIterateArrayAsync(augmentList, base, offset) {
   const length = base.length;
-  const sub = getLinkedList();
+  const sub = getStack();
   let i = -1 + offset;
 
-  return {
-    next: async () => {
-      let keepGoing;
-      do {
-        keepGoing = false;
-        while (sub.hasSomething()) {
-          const result = await sub.last().value.next();
-          if (result.done) {
-            sub.pop();
-          } else {
-            return result;
-          }
+  async function asyncNext() {
+    let keepGoing;
+    do {
+      keepGoing = false;
+      while (sub.hasSomething()) {
+        let result = sub.last().value.next();
+        if (isPromiseLike(result)) {
+          result = await result;
         }
-        iterator:
-        while (++i < length) {
-          const wrapper = { result: base[i] };
-          await resolveState(augmentList, wrapper);
+        if (result.done) {
+          sub.pop();
+        } else {
+          return result;
+        }
+      }
+      arrayAsyncIterator: while (++i < length) {
+        const wrapper = { result: base[i] };
+        const resolving = resolveState(augmentList, wrapper);
+        if (isPromiseLike(resolving)) {
+          await resolving;
+        }
+        switch (wrapper.state) {
+          case STOP:
+            return end;
+          case FLAT:
+            flat(sub, wrapper);
+            keepGoing = true;
+            break arrayAsyncIterator;
+          case YIELD:
+            return {
+              done: false,
+              value: wrapper.result,
+            };
+        };
+      }
+    } while (keepGoing);
+
+    return end;
+  };
+
+  const { asyncSub, asyncProcResolving } = syncToAsyncFactory(sub, asyncNext);
+
+  function syncNext() {
+    let keepGoing;
+    do {
+      keepGoing = false;
+      while (sub.hasSomething()) {
+        const result = sub.last().value.next();
+        if (isPromiseLike(result)) {
+          return asyncSub(result);
+        }
+        if (result.done) {
+          sub.pop();
+        } else {
+          return result;
+        }
+      }
+      arraySyncIterator: while (++i < length) {
+        const wrapper = { result: base[i] };
+        const resolving = resolveState(augmentList, wrapper);
+        if (isPromiseLike(resolving)) {
+          return asyncProcResolving(wrapper, resolving);
+        }
+        switch (wrapper.state) {
+          case STOP:
+            return end;
+          case FLAT:
+            flat(sub, wrapper);
+            keepGoing = true;
+            break arraySyncIterator;
+          case YIELD:
+            return {
+              done: false,
+              value: wrapper.result,
+            };
+        };
+      }
+    } while (keepGoing);
+
+    return end;
+  };
+
+  return {
+    next: syncNext,
+  };
+}
+
+function augmentativeIterateAsyncIterable(augmentList, base, offset) {
+  const sub = getStack();
+  const it = base[Symbol.asyncIterator] ? base[Symbol.asyncIterator]() : base[Symbol.iterator]();
+
+  async function asyncNext() {
+    let keepGoing;
+    do {
+      keepGoing = false;
+      while (sub.hasSomething()) {
+        let result = sub.last().value.next();
+        if (isPromiseLike(result)) {
+          result = await result;
+        }
+        if (!result.done) {
+          return result;
+        }
+        sub.pop();
+      }
+      asyncIterator:
+      do {
+        let next = it.next();
+        if (isPromiseLike(next)) {
+          next = await next;
+        }
+        keepGoing = !next.done;
+        if (offset > 0) {
+          offset--;
+        } else if (keepGoing) {
+          const wrapper = { result: next.value };
+          const resolving = resolveState(augmentList, wrapper);
+          if (isPromiseLike(resolving)) {
+            await resolving;
+          }
           switch (wrapper.state) {
             case STOP:
               return end;
             case FLAT:
               flat(sub, wrapper);
-              keepGoing = true;
-              break iterator;
+              break asyncIterator;
             case YIELD:
               return {
                 done: false,
@@ -102,58 +237,77 @@ function augmentativeIterateArrayAsync(augmentList, base, offset) {
           };
         }
       } while (keepGoing);
+    } while (keepGoing);
 
+    return end;
+  }
+
+  const { asyncSub, asyncProcResolving } = syncToAsyncFactory(sub, asyncNext);
+
+  async function asyncProcNext(next) {
+    next = await next;
+    if (offset > 0) {
+      offset--;
+      return asyncNext();
+    } else if (next.done) {
       return end;
-    },
-  };
-}
+    }
 
-function augmentativeIterateAsyncIterable(augmentList, base, offset) {
-  const sub = getLinkedList();
-  const it = base[Symbol.asyncIterator] ? base[Symbol.asyncIterator]() : base[Symbol.iterator]();
+    const wrapper = { result: next.value };
+    const resolving = resolveState(augmentList, wrapper);
+    return asyncProcResolving(wrapper, resolving);
+  }
 
-  return {
-    next: async () => {
-      let keepGoing;
+  function syncNext() {
+    let keepGoing;
+    do {
+      keepGoing = false;
+      while (sub.hasSomething()) {
+        const result = sub.last().value.next();
+        if (isPromiseLike(result)) {
+          return asyncSub(result);
+        }
+        if (!result.done) {
+          return result;
+        }
+        sub.pop();
+      }
+      syncIterator:
       do {
-        keepGoing = false;
+        const next = it.next();
+        if (isPromiseLike(next)) {
+          return asyncProcNext(next);
+        }
+        keepGoing = !next.done;
         if (offset > 0) {
           offset--;
-          keepGoing = !(await it.next()).done;
-        } else {
-          while (sub.hasSomething()) {
-            const result = await sub.last().value.next();
-            if (result.done) {
-              sub.pop();
-            } else {
-              return result;
-            }
+        } else if (keepGoing) {
+          const wrapper = { result: next.value };
+          const resolving = resolveState(augmentList, wrapper);
+          if (isPromiseLike(resolving)) {
+            return asyncProcResolving(wrapper, resolving);
           }
-          let next = await it.next();
-          iterator:
-          while (!next.done) {
-            const wrapper = { result: next.value };
-            await resolveState(augmentList, wrapper);
-            switch (wrapper.state) {
-              case STOP:
-                return end;
-              case FLAT:
-                flat(sub, wrapper);
-                keepGoing = true;
-                break iterator;
-              case YIELD:
-                return {
-                  done: false,
-                  value: wrapper.result,
-                };
-            };
-            next = await it.next();
-          }
+          switch (wrapper.state) {
+            case STOP:
+              return end;
+            case FLAT:
+              flat(sub, wrapper);
+              break syncIterator;
+            case YIELD:
+              return {
+                done: false,
+                value: wrapper.result,
+              };
+          };
         }
       } while (keepGoing);
+    } while (keepGoing);
 
-      return end;
-    },
+    return end;
+  };
+
+  return {
+    next: syncNext,
     error: it.error?.bind(it),
     return: it.return?.bind(it),
   };
@@ -172,21 +326,21 @@ function augmentativeIterateAsync(next) {
 async function augmentativeForEachAsync(
   action,
 ) {
-  if (this[Symbol.asyncIterator]) {
-    for await (const item of this) {
-      let actResult = action(item);
-      if (isPromiseLike(actResult)) {
-        actResult = await actResult;
+  const it = this[Symbol.asyncIterator] ? this[Symbol.asyncIterator]() : this[Symbol.iterator]();
+  let keepGoing;
+  do {
+    let next = it.next();
+    if (isPromiseLike(next)) {
+      next = await next;
+    }
+    keepGoing = !next.done;
+    if (keepGoing) {
+      const resolving = action(next.value);
+      if (isPromiseLike(resolving)) {
+        await resolving;
       }
     }
-  } else {
-    for (const item of this) {
-      let actResult = action(item);
-      if (isPromiseLike(actResult)) {
-        actResult = await actResult;
-      }
-    }
-  }
+  } while (keepGoing);
 }
 
 function augmentativeToArrayAsync() {

--- a/lib/augmentative-iterable.js
+++ b/lib/augmentative-iterable.js
@@ -14,7 +14,7 @@ const {
   FLAT,
 } = require('./augments-types');
 const {
-  getLinkedList,
+  getStack,
 } = require('./liked-list');
 
 function resolveState(augmentList, wrapper) {
@@ -34,7 +34,7 @@ function resolveState(augmentList, wrapper) {
 
 function augmentativeIterateArray(augmentList, base, offset) {
   const length = base.length;
-  const sub = getLinkedList();
+  const sub = getStack();
   let i = -1 + offset;
 
   return {
@@ -76,7 +76,7 @@ function augmentativeIterateArray(augmentList, base, offset) {
 }
 
 function augmentativeIterateIterable(augmentList, base, offset) {
-  const sub = getLinkedList();
+  const sub = getStack();
   const it = base[Symbol.iterator]();
 
   return {

--- a/lib/liked-list.js
+++ b/lib/liked-list.js
@@ -1,19 +1,9 @@
-function getLinkedList(bootNode) {
+function getStack(bootNode) {
   let first = bootNode;
   let last = bootNode;
   return {
     hasSomething() {
       return !!first;
-    },
-    unshift(value) {
-      const node = { value };
-      if (!first) {
-        last = first = node;
-      } else {
-        node.next = first;
-        first.previous = node;
-        first = node;
-      }
     },
     push(value) {
       const node = { value };
@@ -21,21 +11,7 @@ function getLinkedList(bootNode) {
         first = last = node;
       } else {
         node.previous = last;
-        last = last.next = node;
       }
-    },
-    next() {
-      if (first) {
-        const result = first;
-        first = first.next;
-        if (!first) {
-          last = first;
-        }
-        return result;
-      }
-    },
-    first() {
-      return first;
     },
     last() {
       return last;
@@ -54,5 +30,5 @@ function getLinkedList(bootNode) {
 }
 
 module.exports = {
-  getLinkedList,
+  getStack,
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "npm run lint:format:fix && npm run lint:style:fix",
     "test": "mocha",
     "test:coverage": "nyc npm test",
+    "test:benchmark": "node --expose-gc test-benchmark/index.js",
     "prepublishOnly": "npm run test:coverage",
     "preversion": "npm run test:coverage",
     "version": "scripts/prepare $npm_package_version && git add .",

--- a/test-benchmark/index.js
+++ b/test-benchmark/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-const */
-/* eslint-disable unused-imports/no-unused-vars-ts */
 const fs = require('fs');
 const readline = require('readline');
 const runProfiling = require('./runProfiling');
@@ -144,90 +142,5 @@ function getAsyncIterable(rl) {
 
       console.log(`Read ${i} lines`);
    });
-
-  // await runProfiling('readline async iteration with iteration map', async () => {
-  //   async function *map(iterable) {
-  //     for await (const item of iterable) {
-  //       yield 1;
-  //     }
-  //   }
-
-  //   const rl = readline.createInterface({
-  //       input: fs.createReadStream('./test-benchmark/big.txt'),
-  //     });
-
-  //     let i = 0;
-  //     for await (const line of map(rl)) {
-  //       i += 1;
-  //     }
-
-  //     console.log(`Read ${i} lines`);
-  // });
-
-  // await runProfiling('readline fluent-iterable with map', async () => {
-  //   const rl = readline.createInterface({
-  //       input: fs.createReadStream('./test-benchmark/big.txt'),
-  //     });
-
-  //     const i = await fluentAsync(rl).map(constant(1)).sum();
-
-  //     console.log(`Read ${i} lines`);
-  // });
-
-  // // Modify readline to return an array of lines
-  // // Copied from https://github.com/nodejs/node/blob/efec6811b667b6cf362d648bc599b667eebffce0/lib/readline.js
-  // const lineEnding = /\r?\n|\r(?!\n)/;
-  // readline.Interface.prototype._normalWrite = function(b) {
-  //   if (b === undefined) {
-  //     return;
-  //   }
-  //   let string = this._decoder.write(b);
-  //   if (this._sawReturnAt &&
-  //       DateNow() - this._sawReturnAt <= this.crlfDelay) {
-  //     string = string.replace(/^\n/, '');
-  //     this._sawReturnAt = 0;
-  //   }
-
-  //   // Run test() on the new string chunk, not on the entire line buffer.
-  //   const newPartContainsEnding = lineEnding.test(string);
-
-  //   if (this._line_buffer) {
-  //     string = this._line_buffer + string;
-  //     this._line_buffer = null;
-  //   }
-  //   if (newPartContainsEnding) {
-  //     this._sawReturnAt = string.endsWith('\r') ? DateNow() : 0;
-
-  //     // Got one or more newlines; process into "line" events
-  //     const lines = string.split(lineEnding);
-  //     // Either '' or (conceivably) the unfinished portion of the next line
-  //     string = lines.pop();
-  //     this._line_buffer = string;
-  //     this._onLine(lines); // <- changed from `for of` to `this._onLine(lines)`
-  //   } else if (string) {
-  //     // No newlines this time, save what we have for next time
-  //     this._line_buffer = string;
-  //   }
-  // };
-
-  // readline.Interface.prototype._line = function() {
-  //   const line = this._addHistory();
-  //   this.clearLine();
-  //   this._onLine([line]); // <- changed from `line` to `[line]`
-  // };
-
-  // await runProfiling('readline async iteration via array of lines', async () => {
-  //   const rl = readline.createInterface({
-  //       input: fs.createReadStream('./test-benchmark/big.txt'),
-  //     });
-
-  //     let i = 0;
-  //     for await (const lines of rl) {
-  //       for (const line of lines) {
-  //         i += 1;
-  //       }
-  //     }
-  //     console.log(`Read ${i} lines`);
-  // });
 })();
 

--- a/test-benchmark/index.js
+++ b/test-benchmark/index.js
@@ -1,0 +1,233 @@
+/* eslint-disable prefer-const */
+/* eslint-disable unused-imports/no-unused-vars-ts */
+const fs = require('fs');
+const readline = require('readline');
+const runProfiling = require('./runProfiling');
+const { augmentativeForEachAsync } = require('../lib/augmentative-async-iterable');
+
+
+function getAsyncIterable(rl) {
+  return {
+    [Symbol.asyncIterator]() {
+      let onError;
+      let onClose;
+      let onLine;
+      let queue = {};
+      let error;
+      onError = (value) => {
+        rl.off('close', onClose);
+        rl.off('line', onLine);
+        error = value;
+      };
+      onClose = () => {
+        rl.off('error', onError);
+        rl.off('line', onLine);
+        queue = undefined;
+      };
+      onLine = (value) => {
+        if (queue) {
+          const node = { value };
+          if (queue.last) {
+            queue.last = queue.last.next = node;
+          } else {
+            queue.last = queue.next = node;
+          }
+        }
+      };
+      rl.on('line', onLine);
+      rl.once('error', onError);
+      rl.once('close', onClose);
+      function next() {
+        if (!queue) {
+          return { done: true };
+        }
+        if (error) {
+          throw error;
+        }
+        if (queue.next) {
+          const { value } = queue.next;
+          queue.next = queue.next.next;
+          if (!queue.next) {
+            queue.last = undefined;
+          }
+          return {
+            value,
+          };
+        } else {
+          rl.off('line', onLine);
+          return new Promise((resolve, reject) => {
+            let onErrorOnce;
+            let onCloseOnce;
+            let onLineOnce;
+            onErrorOnce = (value) => {
+              rl.off('close', onCloseOnce);
+              rl.off('line', onLineOnce);
+              reject(value);
+            };
+            onCloseOnce = () => {
+              rl.off('error', onErrorOnce);
+              rl.off('line', onLineOnce);
+              resolve({ done: true });
+            };
+            onLineOnce = (value) => {
+              rl.off('close', onCloseOnce);
+              rl.off('error', onErrorOnce);
+              rl.on('line', onLine);
+              resolve({ value });
+            };
+            rl.once('line', onLineOnce);
+            rl.once('error', onErrorOnce);
+            rl.once('close', onCloseOnce);
+          });
+        }
+      }
+      return {
+        next,
+      };
+    },
+  };
+}
+
+(async () => {
+  await runProfiling('readline stream interface', () => new Promise((resolve, reject) => {
+    const rl = readline.createInterface({
+      input: fs.createReadStream('./test-benchmark/big.txt'),
+    });
+
+    let i = 0;
+    rl.on('line', (line) => {
+      i += 1;
+    });
+
+    rl.on('error', reject);
+
+    rl.on('close', () => {
+      console.log(`Read ${i} lines`);
+      resolve();
+    });
+  }));
+
+  await runProfiling('readline async iteration', async () => {
+    const rl = readline.createInterface({
+        input: fs.createReadStream('./test-benchmark/big.txt'),
+      });
+
+      let i = 0;
+      for await (const line of rl) {
+        i += 1;
+      }
+      console.log(`Read ${i} lines`);
+  });
+
+  await runProfiling('readline manual readline async iterable', async () => {
+    const rl = readline.createInterface({
+        input: fs.createReadStream('./test-benchmark/big.txt'),
+      });
+      const iterable = getAsyncIterable(rl);
+
+      let i = 0;
+      for await (const line of iterable) {
+        i += 1;
+      }
+
+      console.log(`Read ${i} lines`);
+  });
+
+  await runProfiling('readline augmentative-iterable', async () => {
+    const rl = readline.createInterface({
+        input: fs.createReadStream('./test-benchmark/big.txt'),
+      });
+      const iterable = getAsyncIterable(rl);
+
+      let i = 0;
+      await augmentativeForEachAsync.call(iterable, () => i += 1);
+
+      console.log(`Read ${i} lines`);
+   });
+
+  // await runProfiling('readline async iteration with iteration map', async () => {
+  //   async function *map(iterable) {
+  //     for await (const item of iterable) {
+  //       yield 1;
+  //     }
+  //   }
+
+  //   const rl = readline.createInterface({
+  //       input: fs.createReadStream('./test-benchmark/big.txt'),
+  //     });
+
+  //     let i = 0;
+  //     for await (const line of map(rl)) {
+  //       i += 1;
+  //     }
+
+  //     console.log(`Read ${i} lines`);
+  // });
+
+  // await runProfiling('readline fluent-iterable with map', async () => {
+  //   const rl = readline.createInterface({
+  //       input: fs.createReadStream('./test-benchmark/big.txt'),
+  //     });
+
+  //     const i = await fluentAsync(rl).map(constant(1)).sum();
+
+  //     console.log(`Read ${i} lines`);
+  // });
+
+  // // Modify readline to return an array of lines
+  // // Copied from https://github.com/nodejs/node/blob/efec6811b667b6cf362d648bc599b667eebffce0/lib/readline.js
+  // const lineEnding = /\r?\n|\r(?!\n)/;
+  // readline.Interface.prototype._normalWrite = function(b) {
+  //   if (b === undefined) {
+  //     return;
+  //   }
+  //   let string = this._decoder.write(b);
+  //   if (this._sawReturnAt &&
+  //       DateNow() - this._sawReturnAt <= this.crlfDelay) {
+  //     string = string.replace(/^\n/, '');
+  //     this._sawReturnAt = 0;
+  //   }
+
+  //   // Run test() on the new string chunk, not on the entire line buffer.
+  //   const newPartContainsEnding = lineEnding.test(string);
+
+  //   if (this._line_buffer) {
+  //     string = this._line_buffer + string;
+  //     this._line_buffer = null;
+  //   }
+  //   if (newPartContainsEnding) {
+  //     this._sawReturnAt = string.endsWith('\r') ? DateNow() : 0;
+
+  //     // Got one or more newlines; process into "line" events
+  //     const lines = string.split(lineEnding);
+  //     // Either '' or (conceivably) the unfinished portion of the next line
+  //     string = lines.pop();
+  //     this._line_buffer = string;
+  //     this._onLine(lines); // <- changed from `for of` to `this._onLine(lines)`
+  //   } else if (string) {
+  //     // No newlines this time, save what we have for next time
+  //     this._line_buffer = string;
+  //   }
+  // };
+
+  // readline.Interface.prototype._line = function() {
+  //   const line = this._addHistory();
+  //   this.clearLine();
+  //   this._onLine([line]); // <- changed from `line` to `[line]`
+  // };
+
+  // await runProfiling('readline async iteration via array of lines', async () => {
+  //   const rl = readline.createInterface({
+  //       input: fs.createReadStream('./test-benchmark/big.txt'),
+  //     });
+
+  //     let i = 0;
+  //     for await (const lines of rl) {
+  //       for (const line of lines) {
+  //         i += 1;
+  //       }
+  //     }
+  //     console.log(`Read ${i} lines`);
+  // });
+})();
+

--- a/test-benchmark/runProfiling.js
+++ b/test-benchmark/runProfiling.js
@@ -1,0 +1,31 @@
+const runs = process.env.RUNS || 3;
+
+async function runProfiling(name, run) {
+  console.log('');
+  console.log('####################################################');
+  console.log(`WARMUP: Current memory usage: ${currentMemoryUsage({runGarbageCollector: true})} MB`);
+  console.log(`WARMUP: ${name} profiling started`);
+  const warmupStartTime = Date.now();
+  await run();
+  console.log(`WARMUP: ${name} profiling finished in ${Date.now() - warmupStartTime}ms`);
+  console.log(`WARMUP: Current memory usage (before GC): ${currentMemoryUsage({runGarbageCollector: false})} MB`);
+  console.log(`WARMUP: Current memory usage (after GC): ${currentMemoryUsage({runGarbageCollector: true})} MB`);
+
+  for (let i = 1; i <= runs; i += 1) {
+    console.log('');
+    console.log('####################################################');
+    console.log(`RUN ${i}: ${name} profiling started`);
+    const startTime = Date.now();
+    await run(); // eslint-disable-line no-await-in-loop
+    console.log(`RUN ${i}: ${name} profiling finished in ${Date.now() - startTime}ms`);
+    console.log(`RUN ${i}: Current memory usage (before GC): ${currentMemoryUsage({runGarbageCollector: false})} MB`);
+    console.log(`RUN ${i}: Current memory usage (after GC): ${currentMemoryUsage({runGarbageCollector: true})} MB`);
+  }
+}
+
+function currentMemoryUsage({runGarbageCollector}) {
+  if (runGarbageCollector) global.gc();
+  return Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) / 100;
+}
+
+module.exports = runProfiling;

--- a/test/async-iterable.spec.ts
+++ b/test/async-iterable.spec.ts
@@ -270,4 +270,30 @@ describe('AsyncIterable', () => {
 
     expect(result).to.be.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
+
+  it('should apply flatMap over a sync iterable of async iterables', async () => {
+    const original = [
+      toAsync([1, 2, 3]),
+      toAsync([4, 5, 6]),
+      toAsync([7, 8, 9]),
+    ][Symbol.iterator]();
+
+    const transformed = flatMapAsyncIterable(original);
+    const result = await augmentativeToArrayAsync.call(transformed);
+
+    expect(result).to.be.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('should apply flatMap over an async iterable of sync iterables', async () => {
+    const original = toAsync([
+      [1, 2, 3][Symbol.iterator](),
+      [4, 5, 6][Symbol.iterator](),
+      [7, 8, 9][Symbol.iterator](),
+    ]);
+
+    const transformed = flatMapAsyncIterable(original);
+    const result = await augmentativeToArrayAsync.call(transformed);
+
+    expect(result).to.be.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
 });


### PR DESCRIPTION
This feature makes async iterables to be processed synchronously everytime it's possible.

When it's possible? When the next function from the async iterator returns a non-promise value, or when you use augmentativeForEachAsync to iterate over a sync iterator.

Natively, async iterators don't return non-promise values, but augmentative-iterators can do that.

From my tests, this can assure a performance 10% to 40% better over async iterations, specially when you're talking about chained iterators