### PR TITLE
feat: adding support for immutability

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-magic-numbers */
-export declare const augments: unique symbol;
-export declare const baseIterable: unique symbol;
 export declare type AnyIterable<T> = Iterable<T> | AsyncIterable<T>;
 /**
  * Represents a predicate on type `T`.<br>
@@ -96,151 +94,188 @@ export declare function augmentativeToArrayAsync<T>(
  * Returns an iterable that returns only the values of the original iterable that passes the informed predicate
  * @param it the original iterable
  * @param mapper the predicate function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function filterIterable<T>(
   it: Iterable<T>,
   predicate: Predicate<T>,
+  isImmutable?: boolean,
 ): Iterable<T>;
 /**
  * Returns an async iterable that returns only the values of the original async iterable that passes the informed predicate
  * @param it the original async iterable or iterable
  * @param mapper the predicate function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function filterAsyncIterable<T>(
   it: AnyIterable<T>,
   predicate: AsyncPredicate<T>,
+  isImmutable?: boolean,
 ): AsyncIterable<T>;
 /**
  * Returns an iterable that maps each value of the iterable using the function provided
  * @param it the original iterable
  * @param mapper the mapping function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function mapIterable<T, R>(
   it: Iterable<T>,
   mapper: Mapper<T, R>,
+  isImmutable?: boolean,
 ): Iterable<R>;
 
 /**
  * Returns an async iterable that maps each value of the async iterable using the function provided
  * @param it the original async iterable or iterable
  * @param mapper the mapping function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function mapAsyncIterable<T, R>(
   it: AnyIterable<T>,
   mapper: AsyncMapper<T, R>,
+  isImmutable?: boolean,
 ): AsyncIterable<R>;
 
 /**
  * Add a flatMap augment for the iterable. It will returns a new iterable with tne new mapped item type.
  * @param it the original iterable
  * @param mapper the mapping function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
-export declare function flatMapIterable<T, R = T extends AnyIterable<infer Sub> ? Sub : never>(
+export declare function flatMapIterable<
+  T,
+  R = T extends AnyIterable<infer Sub> ? Sub : never
+>(
   it: Iterable<T>,
   mapper?: AsyncMapper<T, AnyIterable<R>>,
+  isImmutable?: boolean,
 ): Iterable<R>;
 
 /**
  * Add a flatMap augment for the iterable. It will returns a new iterable with tne new mapped item type.
  * @param it the original iterable
  * @param mapper the mapping function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
-export declare function flatMapAsyncIterable<T, R = T extends AnyIterable<infer Sub> ? Sub : never>(
+export declare function flatMapAsyncIterable<
+  T,
+  R = T extends AnyIterable<infer Sub> ? Sub : never
+>(
   it: AnyIterable<T>,
   mapper?: AsyncMapper<T, AnyIterable<R>>,
+  isImmutable?: boolean,
 ): AsyncIterable<R>;
 /**
  * Skips the first offset elements and then yields the next ones
  * @param it the original iterable
  * @param offset the number of offset elements
  */
- export declare function skipIterable<T>(
+export declare function skipIterable<T>(
   it: Iterable<T>,
   offset: number,
+  isImmutable?: boolean,
 ): Iterable<T>;
 
 /**
  * Skips the first offset elements and then yields the next ones
  * @param it the original async iterable
  * @param offset the number of offset elements
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function skipAsyncIterable<T>(
   it: AnyIterable<T>,
   offset: number,
+  isImmutable?: boolean,
 ): AsyncIterable<T>;
 /**
  * Returns an iterable that stop to iterate over the values of the original iterable when the informed condition resolves to true.
  * @param it the original iterable
  * @param predicate the stop condition
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function takeWhileIterable<T>(
   it: Iterable<T>,
   predicate: Predicate<T>,
+  isImmutable?: boolean,
 ): Iterable<T>;
 /**
  * Returns an async iterable that stop to iterate over the values of the original async iterable when the informed condition resolves to true.
  * @param it the original iterable or async iterable
  * @param predicate the stop condition
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function takeWhileAsyncIterable<T>(
   it: AnyIterable<T>,
   predicate: AsyncPredicate<T>,
+  isImmutable?: boolean,
 ): AsyncIterable<T>;
 
 /**
  * Add a filter augment for the iterable. It will returns a new iterable if the informed is not already augmentative.
  * @param it the original iterable
  * @param mapper the predicate function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function addFilter<T>(
   it: Iterable<T>,
   predicate: Predicate<T>,
+  isImmutable?: boolean,
 ): Iterable<T>;
 /**
  * Add a filter augment for the async iterable. It will returns a new iterable if the informed is not already augmentative.
  * @param it the original async iterable or iterable
  * @param mapper the predicate function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function addFilterAsync<T>(
   it: AnyIterable<T>,
   predicate: AsyncPredicate<T>,
+  isImmutable?: boolean,
 ): AsyncIterable<T>;
 /**
  * Add a map augment for the iterable. It will returns a new iterable if the informed is not already augmentative.
  * @param it the original iterable
  * @param mapper the mapping function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function addMap<T, R>(
   it: Iterable<T>,
   mapper: Mapper<T, R>,
+  isImmutable?: boolean,
 ): Iterable<R>;
 
 /**
  * Add a map augment for the async iterable. It will returns a new iterable if the informed is not already augmentative.
  * @param it the original async iterable or iterable
  * @param mapper the mapping function
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function addMapAsync<T, R>(
   it: AnyIterable<T>,
   mapper: AsyncMapper<T, R>,
+  isImmutable?: boolean,
 ): AsyncIterable<R>;
 /**
  * Add a takeWhile augment for the iterable. It will returns a new iterable if the informed is not already augmentative.
  * @param it the original iterable
  * @param predicate the stop condition
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function addTakeWhile<T>(
   it: Iterable<T>,
   predicate: Predicate<T>,
+  isImmutable?: boolean,
 ): Iterable<T>;
 /**
  * Add a takeWhile augment for the async iterable. It will returns a new iterable if the informed is not already augmentative.
  * @param it the original iterable or async iterable
  * @param predicate the stop condition
+ * @param isImmutable defines if the next augmentations will emit a new iterable or change the current in place. Only takes effect at the first one of the augmentation chain
  */
 export declare function addTakeWhileAsync<T>(
   it: AnyIterable<T>,
   predicate: AsyncPredicate<T>,
+  isImmutable?: boolean,
 ): AsyncIterable<T>;
 
 /**

--- a/lib/augmentative-async-iterable.js
+++ b/lib/augmentative-async-iterable.js
@@ -15,13 +15,15 @@ const {
 } = require('./augments-types');
 
 function resolveState(augmentList, value) {
-  let next = augmentList;
+  let ai = -1;
   let state = YIELD;
   let type;
+  const { length } = augmentList;
   function recursive(chain) {
-    while (next) {
-      next = next.next;
-      if (next !== augmentList.next) {
+    while (ai < length) {
+      ai++;
+      const next = augmentList[ai];
+      if (ai !== 0) {
         if (type === YIELD) value = chain;
         else if (!chain) {
           state = type;
@@ -55,58 +57,63 @@ function asyncProcResolvingFactory(next) {
 function augmentativeIterateArrayAsync(augmentList, base, offset) {
   const length = base.length;
   let i = -1 + offset;
-  const next = () => {
-    while (++i < length) {
-      const result = resolveState(augmentList, base[i]);
-      if (result) return isPromiseLike(result) ? asyncProcResolving(result) : result;
-    }
-
-    return end;
-  };
-  const asyncProcResolving = asyncProcResolvingFactory(next);
-
-  return {
-    next,
-  };
-}
-
-function augmentativeIterateAsyncIterable(augmentList, base, offset) {
-  const it = base[Symbol.asyncIterator] ? base[Symbol.asyncIterator]() : base[Symbol.iterator]();
-  const next = () => {
-    let keepGoing = false;
+  const syncNext = () => {
+    let keepGoing;
     do {
-      const item = it.next();
-      if (isPromiseLike(item)) return item.then(asyncProcNext);
-      keepGoing = !item.done;
-      if (keepGoing) {
-        if (offset > 0) offset--;
-        else {
-          const result = resolveState(augmentList, item.value);
-          if (result) return isPromiseLike(result) ? asyncProcResolving(result) : result;
-        }
+      keepGoing = false;
+      while (++i < length) {
+        const result = resolveState(augmentList, base[i]);
+        if (isPromiseLike(result)) return asyncProcResolving(result);
+        if (result) return result;
       }
     } while (keepGoing);
 
     return end;
   };
-  const asyncProcResolving = asyncProcResolvingFactory(next);
+  const asyncProcResolving = asyncProcResolvingFactory(syncNext);
 
-  const processNext = (item) => {
-    if (item.done) return end;
-    const result = resolveState(augmentList, item.value);
-    if (result) return isPromiseLike(result) ? asyncProcResolving(result) : result;
-    return next();
+  return {
+    next: syncNext,
+  };
+}
+
+function augmentativeIterateAsyncIterable(augmentList, base, offset) {
+  const it = base[Symbol.asyncIterator] ? base[Symbol.asyncIterator]() : base[Symbol.iterator]();
+  const syncNext = () => {
+    let keepGoing = false;
+    do {
+      const next = it.next();
+      if (isPromiseLike(next)) return next.then(asyncProcNext);
+      keepGoing = !next.done;
+      if (offset > 0) offset--;
+      else if (keepGoing) {
+        const result = resolveState(augmentList, next.value);
+        if (isPromiseLike(result)) return asyncProcResolving(result);
+        if (result) return result;
+      }
+    } while (keepGoing);
+
+    return end;
+  };
+  const asyncProcResolving = asyncProcResolvingFactory(syncNext);
+
+  const processNext = (next) => {
+    if (next.done) return end;
+    const result = resolveState(augmentList, next.value);
+    if (isPromiseLike(result)) return asyncProcResolving(result);
+    if (result) return result;
+    return syncNext();
   };
 
-  let asyncProcNext = offset > 0 ? (item) => {
-    if (item.done) return end;
+  let asyncProcNext = offset > 0 ? (next) => {
+    if (next.done) return end;
     offset--;
     if (offset <= 0) asyncProcNext = processNext;
-    return next();
+    return syncNext();
   } : processNext;
 
   return {
-    next,
+    next: syncNext,
     error: it.error ? it.error.bind(it) : undefined,
     return: it.return ? it.return.bind(it) : undefined,
   };
@@ -123,17 +130,17 @@ function augmentativeForEachAsync(
 ) {
   const it = this[Symbol.asyncIterator] ? this[Symbol.asyncIterator]() : this[Symbol.iterator]();
   let keepGoing = true;
-  const processNext = (item) => {
-    keepGoing = !item.done;
-    if (keepGoing) return action(item.value);
+  const ṕrocessNextPromise = (x) => resolverAsync(processNext(x), recursive);
+  const processNext = (next) => {
+    keepGoing = !next.done;
+    if (keepGoing) return action(next.value);
   };
-  const ṕrocessNextPromise = (item) => resolverAsync(processNext(item), recursive);
   const recursive = async () => {
     while (keepGoing) {
-      let item = it.next();
-      if (isPromiseLike(item)) return item.then(ṕrocessNextPromise);
-      item = processNext(item);
-      if (isPromiseLike(item)) return item.then(recursive);
+      let next = it.next();
+      if (isPromiseLike(next)) return next.then(ṕrocessNextPromise);
+      next = processNext(next);
+      if (isPromiseLike(next)) return next.then(recursive);
     }
   };
 

--- a/lib/augmentative-iterable.js
+++ b/lib/augmentative-iterable.js
@@ -13,13 +13,14 @@ const {
 } = require('./augments-types');
 
 function resolveState(augmentList, value) {
-  let ai = augmentList.next;
-  while (ai) {
-    const { action, type } = ai;
+  let ai = 0;
+  const { length } = augmentList;
+  while (ai < length) {
+    const { action, type } = augmentList[ai];
     const actionResult = action ? action(value) : value;
     if (type === YIELD) value = actionResult;
     else if (!actionResult) return type === STOP ? end : undefined;
-    ai = ai.next;
+    ai++;
   }
   return {
     done: false,

--- a/lib/augments-utils.js
+++ b/lib/augments-utils.js
@@ -41,7 +41,7 @@ const getSkippedAugmentIterable = (
     [iteratorType]: augmentativeIterate,
     [baseIterable]: it,
     [offsetSymbol]: (baseOffset || 0) + Math.max(offset, 0),
-    [addAugmentation]: isImmutable ? addImmutableAugmentation : addMutableAugmentation,
+    [addAugmentation]: it[addAugmentation] || (isImmutable ? addImmutableAugmentation : addMutableAugmentation),
   };
 };
 

--- a/lib/augments-utils.js
+++ b/lib/augments-utils.js
@@ -2,6 +2,7 @@
 
 const offsetSymbol = Symbol('offset');
 const baseIterable = Symbol('BaseIterableSymbol');
+const addAugmentation = Symbol('addAugmentation');
 const augments = Symbol('AugmentSymbol');
 const end = {
   done: true,
@@ -23,44 +24,67 @@ function itClone(it) {
     [iteratorType]: it[augments] ? it[iteratorType] : it[iteratorType].bind(it),
     [augments]: it[augments],
     [baseIterable]: it[baseIterable],
+    [addAugmentation]: it[addAugmentation],
   };
 }
 
 const getSkippedAugmentIterable = (
   iteratorType,
   augmentativeIterate,
-) => function (it, offset = 0) {
+) => function (it, offset = 0, isImmutable) {
   const augmentList = it[augments];
   let baseOffset;
 
-  if (!augmentList || !augmentList.last) baseOffset = it[offsetSymbol];
+  if (!augmentList || augmentList.length === 0) baseOffset = it[offsetSymbol];
 
   return {
     [iteratorType]: augmentativeIterate,
     [baseIterable]: it,
     [offsetSymbol]: (baseOffset || 0) + Math.max(offset, 0),
+    [addAugmentation]: isImmutable ? addImmutableAugmentation : addMutableAugmentation,
   };
 };
+
+function addMutableAugmentation(type, action) {
+  this[augments].push({
+    type,
+    action,
+  });
+  return this;
+}
+
+function addImmutableAugmentation(type, action, iteratorType, augmentativeIterate) {
+  const augmentList = this[augments];
+  const { length } = augmentList;
+  const newAugmentList = new Array(length + 1);
+  for (let i = 0; i < length; i++) newAugmentList[i] = augmentList[i];
+  newAugmentList[length] = {
+    type,
+    action,
+  };
+  return {
+    [iteratorType]: augmentativeIterate,
+    [augments]: newAugmentList,
+    [baseIterable]: this[baseIterable],
+    [addAugmentation]: addImmutableAugmentation,
+  };
+}
 
 const getAugmentIterable = (
   iteratorType,
   augmentativeIterate,
   type,
-) => function (it, action,) {
-  const augmentList = it[augments];
-  const augment = {
-    type,
-    action,
-  };
-  if (augmentList && it[iteratorType]) {
-    augmentList.last = augmentList.last.next = augment;
-    return it;
-  }
+) => function (it, action, isImmutable) {
+  if (it[augments] && it[iteratorType]) return it[addAugmentation](type, action, iteratorType, augmentativeIterate);
 
   return {
     [iteratorType]: augmentativeIterate,
-    [augments]: { next: augment, last: augment },
+    [augments]: [{
+      type,
+      action,
+    }],
     [baseIterable]: it,
+    [addAugmentation]: isImmutable ? addImmutableAugmentation : addMutableAugmentation,
   };
 };
 
@@ -71,13 +95,13 @@ function getIterableParameters(self, next, iteratorSymbol, augmentativeIterate) 
   let base;
   const offset = self[offsetSymbol] || 0;
   if (!next) {
-    augmentList = self[augments] || {};
+    augmentList = self[augments] || [];
     base = self[baseIterable] || self;
   } else {
     base = {
       [iteratorSymbol]: augmentativeIterate.bind(self),
     };
-    augmentList = { next, last: next };
+    augmentList = [next];
   }
 
   return { augmentList, base, offset };

--- a/test/async-iterable.spec.ts
+++ b/test/async-iterable.spec.ts
@@ -128,7 +128,7 @@ describe('AsyncIterable', () => {
     expect(result).to.be.eql([5, 8, 11]);
   });
 
-  it('should add an augmentative argument when iterable is already augmentative', async () => {
+  it('should add an augmentative argument when iterable is already augmentative when iterable is mutable', async () => {
     const original = [1, 2, 3];
     const result: number[] = [];
 
@@ -140,6 +140,28 @@ describe('AsyncIterable', () => {
 
     expect(map1).to.be.eq(map2);
     expect(result).to.be.eql([7, 10, 13]);
+  });
+
+  it('should support branching when iterable is immutable', async () => {
+    const original = [1, 2, 3];
+    const result0: number[] = [];
+    const result1: number[] = [];
+    const result2: number[] = [];
+
+    const map1 = mapAsyncIterable(original, async (x) => x * 3, true);
+    const map2 = addMapAsync(map1, (x) => x + 2);
+
+    await augmentativeForEachAsync.call(map2, (async (x: number) =>
+      result2.push(x + 2)) as any);
+    await augmentativeForEachAsync.call(map1, (async (x: number) =>
+      result1.push(x + 2)) as any);
+    await augmentativeForEachAsync.call(original, (async (x: number) =>
+      result0.push(x + 2)) as any);
+
+    expect(map1).not.to.be.eq(map2);
+    expect(result0).to.be.eql([3, 4, 5]);
+    expect(result1).to.be.eql([5, 8, 11]);
+    expect(result2).to.be.eql([7, 10, 13]);
   });
 
   it('should return an augmentative iterable with adding operation when informed iterable is not augmentative', async () => {

--- a/test/iterable.spec.ts
+++ b/test/iterable.spec.ts
@@ -189,7 +189,7 @@ describe('Iterable', () => {
     expect(result).to.be.eql([5, 8, 11]);
   });
 
-  it('should add an augmentative argument when iterable is already augmentative', async () => {
+  it('should add an augmentative argument when iterable is already augmentative when iterable is mutable', async () => {
     const original = [1, 2, 3];
     const result: number[] = [];
 
@@ -201,6 +201,28 @@ describe('Iterable', () => {
 
     expect(map1).to.be.eq(map2);
     expect(result).to.be.eql([7, 10, 13]);
+  });
+
+  it('should support branching when iterable is immutable', () => {
+    const original = [1, 2, 3];
+    const result0: number[] = [];
+    const result1: number[] = [];
+    const result2: number[] = [];
+
+    const map1 = mapIterable(original, (x) => x * 3, true);
+    const map2 = addMap(map1, (x) => x + 2);
+
+    augmentativeForEach.call(map2, (async (x: number) =>
+      result2.push(x + 2)) as any);
+    augmentativeForEach.call(map1, (async (x: number) =>
+      result1.push(x + 2)) as any);
+    augmentativeForEach.call(original, (async (x: number) =>
+      result0.push(x + 2)) as any);
+
+    expect(map1).not.to.be.eq(map2);
+    expect(result0).to.be.eql([3, 4, 5]);
+    expect(result1).to.be.eql([5, 8, 11]);
+    expect(result2).to.be.eql([7, 10, 13]);
   });
 
   it('should return an augmentative iterable with adding operation when informed iterable is not augmentative', async () => {


### PR DESCRIPTION
This lib was generating mutable objects
by definition, but, for a easier use, now, when
can inforem we want the iterables will be immutable
at the first call, which will allow branching
an iterable into multiples transformations if it
supports being iterated twice.