### PR TITLE
fix: improving to-array

### DIFF
--- a/lib/augmentative-iterable.js
+++ b/lib/augmentative-iterable.js
@@ -88,9 +88,7 @@ function augmentativeForEach(
 
 function augmentativeToArray() {
   const result = [];
-
-  augmentativeForEach.call(this, result.push.bind(result));
-
+  for (const item of this) result.push(item);
   return result;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "augmentative-iterable",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "augmentative-iterable",
   "description": "This project is just a template for creation of new projects",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": false,
   "author": {
     "name": "Thiago O Santos <tos.oliveira@gmail.com>"

--- a/test/unit/iterable.spec.ts
+++ b/test/unit/iterable.spec.ts
@@ -10,6 +10,7 @@ import {
   addMapAsync,
   flatMapIterable,
   skipIterable,
+  augmentativeToArrayAsync,
 } from '../../index';
 import { expect } from 'chai';
 import { stub } from 'sinon';
@@ -254,7 +255,7 @@ describe('Iterable', () => {
     expect(result).to.be.eql([2, 3]);
   });
 
-  it('should respect filter and takeWhile through operations', () => {
+  it('should respect filter and takeWhile through operations', async () => {
     const callFilter = stub().callsFake((x) => x !== 2);
     const callTakeWhile = stub().callsFake((x) => x < 4);
     const callMap = stub().callsFake((x) => x);
@@ -263,7 +264,7 @@ describe('Iterable', () => {
     const takeWhile = addTakeWhile(filter, callTakeWhile);
     const map: any = addMapAsync(takeWhile, callMap);
 
-    const result = augmentativeToArray.call(map);
+    const result = await augmentativeToArrayAsync.call(map);
 
     expect(result).to.be.eql([1, 3]);
     expect(callFilter).to.have.callsLike([1], [2], [3], [4]);


### PR DESCRIPTION
After benchmarking different ways of implementing
to-array, we chose to use for of + push, as it has shown the best performance for the cases this library is focused on